### PR TITLE
Fix compile error on ubuntu

### DIFF
--- a/NTPDoser.cpp
+++ b/NTPDoser.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <string.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <unistd.h>
 #include <stdint.h>
 #include <sys/time.h>


### PR DESCRIPTION
error: ‘printf’ was not declared in this scope